### PR TITLE
Fix HTTP routing to serve maintenance page

### DIFF
--- a/backend/routes/routes.go
+++ b/backend/routes/routes.go
@@ -6,7 +6,6 @@ package routes
 
 import (
 	// import packages
-	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -23,12 +22,16 @@ func Routes() *http.ServeMux {
 	// The routes to pages
 	siteMode := os.Getenv("SITE_MODE")
 	switch strings.ToLower(siteMode) {
-	case "dev", "devmode":
+	case "dev", "devmode", "":
+		if siteMode == "" {
+			logging.Logger.Warn("SITE_MODE not set, defaulting to maintenance mode")
+		}
 		Mux.HandleFunc("/", handlers.MaintainenceHandler)
 	case "live":
 		Mux.HandleFunc("/", handlers.IndexHandler)
 	default:
-		log.Fatalf("Error: Unknown SITE_MODE '%s'. Expected 'dev' or 'live'.", siteMode)
+		logging.Logger.Warn("Unknown SITE_MODE, defaulting to maintenance mode", "site_mode", siteMode)
+		Mux.HandleFunc("/", handlers.MaintainenceHandler)
 	}
 
 	// Return Mux to allow it to be served in main.go

--- a/main.go
+++ b/main.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"log"
 	"net/http"
 
 	"github.com/djmcodechain/Portfolio/backend/logging"
+	"github.com/djmcodechain/Portfolio/backend/routes"
 )
 
 // Path: backend/cmd/main.go
@@ -11,12 +13,16 @@ import (
 // GitHub: https://github.com/djmcodechain/Portfolio
 func main() {
 	defer logging.Logger.Info("main() ~ called")
-	// Serve Static Files
-	fs := http.FileServer(http.Dir("../../frontend/assets"))
-	http.Handle("/assets/", http.StripPrefix("/assets/", fs))
+	mux := routes.Routes()
 
-	println("Listening on http://localhost:8080")
-	http.ListenAndServe(":8080", nil)
+	fs := http.FileServer(http.Dir("frontend/assets"))
+	mux.Handle("/assets/", http.StripPrefix("/assets/", fs))
+
+	addr := ":8080"
+	logging.Logger.Info("HTTP server starting", "addr", addr)
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		log.Fatalf("failed to start HTTP server: %v", err)
+	}
 }
 
 // GNU Public


### PR DESCRIPTION
## Summary
- register the application's HTTP routes so the root path is handled
- serve static assets from the repository's frontend directory
- make SITE_MODE default to the maintenance handler when unset or invalid

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68f49cfc39ec8325b1cccacbb34f4a1c